### PR TITLE
[qfix] Decrease CI timeout

### DIFF
--- a/.cloudtest.yaml
+++ b/.cloudtest.yaml
@@ -1,7 +1,7 @@
 ---
 version: 1.0
 root: "./.tests/cloud_test/"
-timeout: 7200  # 2 hour total total timeout
+timeout: 3600  # 1 hour total total timeout
 shuffle-enabled: true
 statistics:
   enabled: true

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/networkservicemesh/integration-k8s-packet
 go 1.16
 
 require (
-	github.com/networkservicemesh/integration-tests v0.0.0-20210514104822-b69a253a22ac
+	github.com/networkservicemesh/integration-tests v0.0.0-20210608055012-348c7744c1f1
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8m
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/networkservicemesh/gotestmd v0.0.0-20210505083953-36a9ba90c9c6 h1:5Jh5uQYZ/2GHu3ACx0V7lLrriHo2WiyS8V7OM5JLxfw=
 github.com/networkservicemesh/gotestmd v0.0.0-20210505083953-36a9ba90c9c6/go.mod h1:enMZGxL7B1TtqRHx94CiL6JuYIz9/GwBe0DqjL3l3xw=
-github.com/networkservicemesh/integration-tests v0.0.0-20210514104822-b69a253a22ac h1:Fq3nqPVlwwqkXHMBegbFpi8lZSi1J48T85+HQDNVcSg=
-github.com/networkservicemesh/integration-tests v0.0.0-20210514104822-b69a253a22ac/go.mod h1:hiF3iJavLCo5B1pYPO8mm9IGE8TUv832Lu1sM7s3WGc=
+github.com/networkservicemesh/integration-tests v0.0.0-20210608055012-348c7744c1f1 h1:x6likdLex+Q9CAEgTidDvttvN0HziX0UFf8S6874FdY=
+github.com/networkservicemesh/integration-tests v0.0.0-20210608055012-348c7744c1f1/go.mod h1:hiF3iJavLCo5B1pYPO8mm9IGE8TUv832Lu1sM7s3WGc=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
When CI works normally, tests require about 20 minutes to run, and packet cluster in normal conditions also doesn't require too much time to start, so it makes sense to decrease total timeout to 1 hour.