### PR TITLE
Exclude `TestVl3_basic`, `TestVl3_dns`, `TestScale_from_zero` from running in parallel

### DIFF
--- a/tests_default/main_test.go
+++ b/tests_default/main_test.go
@@ -53,5 +53,5 @@ func TestRunObservabilitySuite(t *testing.T) {
 }
 
 func TestFeatureSuite(t *testing.T) {
-	parallel.Run(t, new(features.Suite))
+	parallel.Run(t, new(features.Suite), "TestVl3_basic", "TestVl3_dns", "TestScale_from_zero")
 }


### PR DESCRIPTION
## PR
https://github.com/networkservicemesh/integration-k8s-packet/actions/runs/6588702964/job/17901588610?pr=372