### PR TITLE
Run TestSelect_forwarder sequentially

### DIFF
--- a/tests_calico-vpp/main_test.go
+++ b/tests_calico-vpp/main_test.go
@@ -65,5 +65,5 @@ func (s *featuresSuite) BeforeTest(suiteName, testName string) {
 }
 
 func TestRunFeatureSuiteCalico(t *testing.T) {
-	parallel.Run(t, new(featuresSuite), "TestVl3_basic", "TestVl3_dns", "TestScale_from_zero", "TestVl3_scale_from_zero")
+	parallel.Run(t, new(featuresSuite), "TestVl3_basic", "TestVl3_dns", "TestScale_from_zero", "TestVl3_scale_from_zero", "TestSelect_forwarder")
 }

--- a/tests_default/main_test.go
+++ b/tests_default/main_test.go
@@ -53,5 +53,5 @@ func TestRunObservabilitySuite(t *testing.T) {
 }
 
 func TestFeatureSuite(t *testing.T) {
-	parallel.Run(t, new(features.Suite), "TestVl3_basic", "TestVl3_dns", "TestScale_from_zero", "TestVl3_scale_from_zero")
+	parallel.Run(t, new(features.Suite), "TestVl3_basic", "TestVl3_dns", "TestScale_from_zero", "TestVl3_scale_from_zero", "TestSelect_forwarder")
 }


### PR DESCRIPTION
### Motivation

Closes https://github.com/networkservicemesh/integration-k8s-packet/pull/376

https://github.com/networkservicemesh/integration-k8s-packet/actions/runs/6970784462/job/18969428543?pr=376

`TestSelect_forwarder` adds new forwarders that accidentally can be used by other tests