### PR TITLE
patchesStrategicMerge field in kustomization.yaml files is deprecated.

### DIFF
--- a/scripts/calico/kustomization.yaml
+++ b/scripts/calico/kustomization.yaml
@@ -5,5 +5,5 @@ kind: Kustomization
 resources:
   - https://raw.githubusercontent.com/projectcalico/vpp-dataplane/v3.26.0/yaml/generated/calico-vpp-nohuge.yaml
 
-patchesStrategicMerge:
-  - patch.yaml
+patches:
+  - path: patch.yaml

--- a/scripts/defaultCNI/kustomization.yaml
+++ b/scripts/defaultCNI/kustomization.yaml
@@ -5,5 +5,5 @@ kind: Kustomization
 resources:
   - https://raw.githubusercontent.com/projectcalico/calico/v3.25.0/manifests/calico.yaml
 
-patchesStrategicMerge:
-  - patch.yaml
+patches:
+  - path: patch.yaml


### PR DESCRIPTION
https://github.com/networkservicemesh/deployments-k8s/issues/9036

cc @NikitaSkrynnik @denis-tingaikin 