### PR TITLE
add vl3 tests to excluded tests

### DIFF
--- a/test/calico-vpp/main_test.go
+++ b/test/calico-vpp/main_test.go
@@ -73,5 +73,9 @@ func TestRunFeatureSuiteCalico(t *testing.T) {
 			featSuite.TestVl3_dns,
 			featSuite.TestVl3_scale_from_zero,
 			featSuite.TestScale_from_zero,
-			featSuite.TestSelect_forwarder))
+			featSuite.TestSelect_forwarder,
+			featSuite.TestVl3_scale_from_zero,
+			featSuite.TestVl3_ipv6,
+			featSuite.TestVl3_lb,
+			featSuite.TestScaled_registry))
 }

--- a/test/default/feature_test.go
+++ b/test/default/feature_test.go
@@ -34,5 +34,6 @@ func TestFeatureSuite(t *testing.T) {
 			featuresSuite.TestVl3_lb,
 			featuresSuite.TestVl3_scale_from_zero,
 			featuresSuite.TestScale_from_zero,
-			featuresSuite.TestSelect_forwarder))
+			featuresSuite.TestSelect_forwarder,
+			featuresSuite.TestScaled_registry))
 }


### PR DESCRIPTION
## Description
`vl3` tests conflict with `scaled registry` tests. `vl3` endpoints can't register themselves because `scaled registry` test deletes registries
## Issue
https://github.com/networkservicemesh/integration-k8s-aws/actions/runs/10179324617/job/28154806977